### PR TITLE
Fix directory path for dogfooding and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,3 +166,19 @@ Safely converts a markdown string to HTML and outputs it.
 ```php
 wpcl_markdown( '## This will become an h2' );
 ```
+
+## Loading Styles
+
+If you are using styles that are scoped to your components (e.g., a style.scss
+file in each component directory) you will need to make sure that you are
+running a build of those component styles that is loaded in the admin via the
+`admin_enqueue_scripts` hook so the styles are previewable in the admin view.
+
+## Local Development
+
+The admin views for this plugin are produced using components built using this
+plugin, which allows us to "eat our own dog food," or use the plugin to develop
+the plugin. In order to switch the behavior of the plugin from previewing
+components in the active theme to previewing the components that are used in
+this plugin, simply append `&dogfooding=1` to the admin URL for the components
+view.

--- a/inc/class-component.php
+++ b/inc/class-component.php
@@ -208,7 +208,7 @@ class Component {
 		// If we're dogfooding, look in our own component dir.
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( isset( $_GET['dogfooding'] ) && true === (bool) $_GET['dogfooding'] ) {
-			return [ dirname( __DIR__, 2 ) ];
+			return [ dirname( __DIR__ ) ];
 		}
 
 		return [


### PR DESCRIPTION
## Summary

Fixes a bug related to dogfooding paths due to a late-breaking change in getting PHPUnit working with GitHub Actions.

Updates the README to include information on loading styles and how to dogfood the plugin.

## Notes for reviewers

None.

## Changelog entries

- **Added**: README instructions on loading styles and dogfooding.
- **Fixed**: Directory path when dogfooding.

## Issue(s)

None.
