### PR TITLE
Convert class and ID functions to generic attributes function

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,31 +130,35 @@ was provided in the props array, or using default values for each prop.
 wpcl_component( 'button', [ 'href' => 'https://www.example.org', 'text' => 'Visit example.org' ] );
 ```
 
-### wpcl_class
+### wpcl_attributes
 
-Accepts arguments in the same fashion as the
-[classnames npm package](https://www.npmjs.com/package/classnames). If there is
-at least one class name in the list, prints a `class` attribute with the list
-of classnames, properly escaped. If there are no classes, does not print
-anything. Useful for applying multiple classes, conditional classes, derived
+Accepts an array of key/value pairs to set as attributes on an HTML element
+and safely outputs them. Optionally, you can pass the `$args` variable as the
+second parameter and the function will intelligently merge props with default
+values. It is recommended to use this approach for attributes on the root
+element of a component to enable support for setting the `id` and `class` props.
+
+The `class` attribute accepts either a normal string of classes, or an array of
+arguments in the same fashion as the
+[classnames npm package](https://www.npmjs.com/package/classnames).
+This is useful for applying multiple classes, conditional classes, derived
 classes, and merging a set of classes with class names that may have been passed
 to a component via props.
 
 #### Example Usage
 
 ```php
-wpcl_class( 'class-1', [ 'class-2', 'class-3' ], [ 'class-4' => $maybe_include ], $args['class'] );
-```
-
-### wpcl_id
-
-Similar to `wpcl_class`, accepts an ID parameter and conditionally outputs an
-`id` attribute. Useful when adding support for the `id` prop to a component.
-
-#### Example Usage
-
-```php
-wpcl_id( $args['id'] );
+<a
+	<?php
+		wpcl_attributes(
+			[
+				'class' => [ 'class-1', [ 'class-2', 'class-3' ], [ 'class-4' => $maybe_include ] ],
+				'href'  => 'https://www.example.org/',
+			],
+			$args
+		);
+	?>
+>
 ```
 
 ### wpcl_markdown

--- a/components/wpcl-admin-notice/template.php
+++ b/components/wpcl-admin-notice/template.php
@@ -9,6 +9,18 @@
 ?>
 
 <div
-	<?php wpcl_class( 'notice', sprintf( 'notice-%s', $args['type'] ), [ 'is-dismissible' => $args['dismissible'] ], $args['class'] ); ?>
-	<?php wpcl_id( $args['id'] ); ?>
+	<?php
+		wpcl_attributes(
+			[
+				'class' => [
+					'notice',
+					sprintf( 'notice-%s', $args['type'] ),
+					[
+						'is-dismissible' => $args['dismissible'],
+					],
+				],
+			],
+			$args
+		);
+		?>
 ><p><?php echo wp_kses_post( $args['text'] ); ?></p></div>

--- a/components/wpcl-button/template.php
+++ b/components/wpcl-button/template.php
@@ -12,12 +12,17 @@ $html_tag  = $is_button ? 'button' : 'a';
 ?>
 
 <<?php echo esc_html( $html_tag ); ?>
-	<?php wpcl_class( 'button', sprintf( 'button--%s', $args['variant'] ), $args['class'] ); ?>
-	<?php if ( ! $is_button ) : ?>
-		href="<?php echo esc_url( $args['href'] ); ?>"
-	<?php endif; ?>
-	<?php wpcl_id( $args['id'] ); ?>
-	<?php if ( $is_button ) : ?>
-		type="<?php echo esc_attr( $args['type'] ); ?>"
-	<?php endif; ?>
+	<?php
+		wpcl_attributes(
+			[
+				'class' => [
+					'button',
+					sprintf( 'button--%s', $args['variant'] ),
+				],
+				'href'  => ! $is_button ? $args['href'] : '',
+				'type'  => $is_button ? $args['type'] : '',
+			],
+			$args
+		);
+		?>
 ><?php echo esc_html( $args['text'] ); ?></<?php echo esc_html( $html_tag ); ?>>

--- a/components/wpcl-code/template.php
+++ b/components/wpcl-code/template.php
@@ -21,7 +21,12 @@ try {
 ?>
 
 <pre
-	<?php wpcl_class( $args['class'] ); ?>
-	<?php wpcl_id( $args['id'] ); ?>
-	style="width: 50%"
+	<?php
+		wpcl_attributes(
+			[
+				'style' => 'width: 50%',
+			],
+			$args
+		);
+		?>
 ><code><?php echo wp_kses_post( $code ); ?></code></pre>

--- a/components/wpcl-heading/template.php
+++ b/components/wpcl-heading/template.php
@@ -9,6 +9,5 @@
 ?>
 
 <h<?php echo absint( $args['level'] ); ?>
-	<?php wpcl_class( $args['class'] ); ?>
-	<?php wpcl_id( $args['id'] ); ?>
+	<?php wpcl_attributes( [], $args ); ?>
 ><?php echo wp_kses_post( $args['text'] ); ?></h<?php echo absint( $args['level'] ); ?>>

--- a/components/wpcl-list/template.php
+++ b/components/wpcl-list/template.php
@@ -9,8 +9,7 @@
 ?>
 
 <<?php echo 'ordered' === $args['type'] ? 'ol' : 'ul'; ?>
-	<?php wpcl_class( $args['class'] ); ?>
-	<?php wpcl_id( $args['id'] ); ?>
+	<?php wpcl_attributes( [], $args ); ?>
 >
 	<?php foreach ( $args['items'] as $item ) : ?>
 		<li>

--- a/components/wpcl-table/template.php
+++ b/components/wpcl-table/template.php
@@ -9,9 +9,14 @@
 ?>
 
 <table
-	<?php wpcl_class( $args['class'] ); ?>
-	<?php wpcl_id( $args['id'] ); ?>
-	style="background: #000"
+	<?php
+		wpcl_attributes(
+			[
+				'style' => 'background: #000',
+			],
+			$args
+		);
+		?>
 >
 	<?php if ( ! empty( $args['header'] ) ) : ?>
 		<thead>

--- a/tests/components/button/template.php
+++ b/tests/components/button/template.php
@@ -12,12 +12,17 @@ $html_tag  = $is_button ? 'button' : 'a';
 ?>
 
 <<?php echo esc_html( $html_tag ); ?>
-	<?php wpcl_class( 'button', sprintf( 'button--%s', $args['variant'] ), $args['class'] ); ?>
-	<?php if ( ! $is_button ) : ?>
-		href="<?php echo esc_url( $args['href'] ); ?>"
-	<?php endif; ?>
-	<?php wpcl_id( $args['id'] ); ?>
-	<?php if ( $is_button ) : ?>
-		type="<?php echo esc_attr( $args['type'] ); ?>"
-	<?php endif; ?>
+	<?php
+		wpcl_attributes(
+			[
+				'class' => [
+					'button',
+					sprintf( 'button--%s', $args['variant'] ),
+				],
+				'href'  => ! $is_button ? $args['href'] : '',
+				'type'  => $is_button ? $args['type'] : '',
+			],
+			$args
+		);
+		?>
 ><?php echo esc_html( $args['text'] ); ?></<?php echo esc_html( $html_tag ); ?>>

--- a/tests/test-component.php
+++ b/tests/test-component.php
@@ -31,7 +31,7 @@ class Test_Component extends WP_UnitTestCase {
 			'Test button example 2' => [
 				'button',
 				1,
-				'<button class="button button--secondary newsletter-signup" id="newsletter-signup-footer" type="button">Sign Up for Our Newsletter</button>',
+				'<button class="button button--secondary newsletter-signup" type="button" id="newsletter-signup-footer">Sign Up for Our Newsletter</button>',
 			],
 		];
 	}


### PR DESCRIPTION
## Summary

Makes it easier to establish attributes by using a consolidated function that handles classes and IDs rather than having separate functions for each.

## Notes for reviewers

None.

## Changelog entries

- **Added**: Added `wpcl_attributes` function.
- **Removed**: Removed `wpcl_class` and `wpcl_id` functions in favor of `wpcl_attributes`.

## Issue(s)

None.
