### PR TITLE
Don't load the plugin if composer install hasn't been run

### DIFF
--- a/wp-component-library.php
+++ b/wp-component-library.php
@@ -15,6 +15,11 @@
  * Author: Alley
  */
 
+// If the autoloader doesn't exist yet (no composer install was performed) bail out.
+if ( ! file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
+	return;
+}
+
 // Composer autoloader.
 require_once __DIR__ . '/vendor/autoload.php';
 


### PR DESCRIPTION
## Summary

As titled.

## Notes for reviewers

None.

## Changelog entries

- **Added**: A check to ensure that the autoload file has been created before attempting to load it and the rest of the plugin.
- **Changed**:
- **Deprecated**:
- **Removed**:
- **Fixed**:
- **Security**:

## Issue(s)

None.
