### PR TITLE
Return component output as string and show errors in admin as notices

### DIFF
--- a/components/wpcl-admin-page/template.php
+++ b/components/wpcl-admin-page/template.php
@@ -77,7 +77,7 @@ if ( ! empty( $featured_component ) ) {
 				'wpcl-admin-notice',
 				[
 					'type' => 'error',
-					'text' => __( 'The component could not be rendered.', 'wp-component-library' )
+					'text' => __( 'The component could not be rendered.', 'wp-component-library' ),
 				]
 			);
 		}

--- a/components/wpcl-admin-page/template.php
+++ b/components/wpcl-admin-page/template.php
@@ -13,6 +13,9 @@ $featured_component = ! empty( $args['component'] )
 	? new Component( $args['component'], [], 'preview' )
 	: null;
 
+// Print any admin notices from erroring components.
+do_action( 'wpcl_admin_notices' );
+
 // Get examples, if there are any.
 $examples       = $featured_component ? $featured_component->get_examples() : [];
 $total_examples = count( $examples );
@@ -67,7 +70,17 @@ if ( ! empty( $featured_component ) ) {
 		);
 
 		// Render the component preview.
-		$featured_component->render();
+		$success = $featured_component->render();
+
+		if ( ! $success ) {
+			wpcl_component(
+				'wpcl-admin-notice',
+				[
+					'type' => 'error',
+					'text' => __( 'The component could not be rendered.', 'wp-component-library' )
+				]
+			);
+		}
 
 		// Construct the sample code and render it.
 		$code = sprintf(

--- a/inc/blocks/trait-interacts-with-blocks.php
+++ b/inc/blocks/trait-interacts-with-blocks.php
@@ -69,8 +69,13 @@ trait Interacts_With_Blocks {
 	public function render_component( ?array $attrs = null, ?string $component_name = null ): void {
 		$attrs          ??= $this->attrs;
 		$component_name ??= 'block-' . str_replace( '/', '-', $this->raw['blockName'] );
-		if ( ! wpcl_component( $component_name, $attrs ) ) {
+		$output           = wpcl_component( $component_name, $attrs, true );
+
+		if ( empty( $output ) ) {
 			$this->render_fallback();
+		} else {
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			echo $output; // Escaped in component template file.
 		}
 	}
 

--- a/inc/class-component.php
+++ b/inc/class-component.php
@@ -14,6 +14,13 @@ namespace WP_Component_Library;
  */
 class Component {
 	/**
+	 * The reason(s) the current component is invalid.
+	 *
+	 * @var string[]
+	 */
+	private array $error_reasons = [];
+
+	/**
 	 * An array of Examples for this component.
 	 *
 	 * @var Example[]
@@ -106,6 +113,7 @@ class Component {
 		$this->locate_component();
 		$this->load_config( 'preview' === $context );
 		$this->load_props( $props );
+		$this->maybe_show_errors();
 	}
 
 	/**
@@ -171,6 +179,37 @@ class Component {
 	}
 
 	/**
+	 * Show errors on WPCL admin screens only.
+	 *
+	 * @return void
+	 */
+	private function maybe_show_errors(): void {
+		if ( empty( $this->error_reasons ) || ! is_admin() ) {
+			return;
+		}
+
+		if ( apply_filters( 'wpcl_hide_component_errors_as_notices', false ) ) {
+			return;
+		}
+
+		foreach ( $this->error_reasons as $error ) {
+			add_action(
+				'wpcl_admin_notices',
+				function() use ( $error ) {
+					$error = "$this->name - $error";
+					wpcl_component(
+						'wpcl-admin-notice',
+						[
+							'type' => 'error',
+							'text' => $error,
+						]
+					);
+				}
+			);
+		}
+	}
+
+	/**
 	 * Renders this template part, using the props system to validate values
 	 * and provide fallbacks. Mimics the behavior of get_template_part, but
 	 * uses the negotiated path established by locate_component instead of
@@ -180,26 +219,50 @@ class Component {
 	 * @return bool True if the component template exists. False otherwise.
 	 */
 	public function render() : bool {
-		// Ensure the template file exists before attempting to render it.
-		if ( ! file_exists( sprintf( '%s/template.php', $this->path ) ) ) {
+		try {
+			// Ensure the template file exists before attempting to render it.
+			if ( ! file_exists( sprintf( '%s/template.php', $this->path ) ) ) {
+				$this->set_error_reason( __( 'No template found.', 'wp-component-library' ) );
+				return false;
+			}
+
+			// Populate values for all props, using defaults if no value is provided.
+			$props = [];
+			foreach ( $this->props as $prop_name => $prop ) {
+				$props[ $prop_name ] = $prop->get_value();
+			}
+
+			/* phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound */
+			$slug = sprintf( 'components/%s/template', $this->name );
+			do_action( "get_template_part_{$slug}", $slug, null, $props );
+			do_action( 'get_template_part', $slug, null, [ "{$slug}.php" ], $props );
+			/* phpcs:enable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound */
+
+			load_template( sprintf( '%s/template.php', $this->path ), false, $props );
+		} catch ( \Throwable $e ) {
+			wpcl_log(
+				sprintf(
+					// translators: the component name and the returned error message.
+					__( 'There was a problem rendering the component: %1$s. Error: %2$s', 'wp-component-library' ),
+					$this->name,
+					$e->getMessage()
+				)
+			);
+			$this->set_error_reason( __( 'There was a throwable error during rendering.', 'wp-component-library' ) );
 			return false;
 		}
-
-		// Populate values for all props, using defaults if no value is provided.
-		$props = [];
-		foreach ( $this->props as $prop_name => $prop ) {
-			$props[ $prop_name ] = $prop->get_value();
-		}
-
-		/* phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound */
-		$slug = sprintf( 'components/%s/template', $this->name );
-		do_action( "get_template_part_{$slug}", $slug, null, $props );
-		do_action( 'get_template_part', $slug, null, [ "{$slug}.php" ], $props );
-		/* phpcs:enable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound */
-
-		load_template( sprintf( '%s/template.php', $this->path ), false, $props );
-
 		return true;
+	}
+
+	/**
+	 * Set's the reason the component cannot be rendered/parsed.
+	 *
+	 * @param string $reason The Reason™.
+	 * @return void
+	 */
+	public function set_error_reason( string $reason ): void {
+		$this->error_reasons[] = $reason;
+		$this->error_reasons   = array_unique( $this->error_reasons );
 	}
 
 	/**
@@ -231,11 +294,18 @@ class Component {
 		// Ensure we have a path and the component file exists.
 		$filepath = sprintf( '%s/component.json', $this->path );
 		if ( empty( $this->path ) || ! file_exists( $filepath ) ) {
+			$this->set_error_reason( __( 'Component JSON configuration not found.', 'wp-component-library' ) );
 			return;
 		}
 
 		// Load the contents of the configuration.
 		$config = json_decode( file_get_contents( $filepath ), true ); // phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown
+
+		if ( is_null( $config ) ) {
+			// translators: the invalid file's name and the name of the current component.
+			wpcl_log( sprintf( __( 'The %1$s config file is invalid for the %2$s component.', 'wp-component-library' ), 'component.json', $this->name ) );
+			$this->set_error_reason( __( 'Component JSON configuration is invalid.', 'wp-component-library' ) );
+		}
 
 		// Set the title.
 		$this->title = $config['title'] ?? '';

--- a/inc/class-component.php
+++ b/inc/class-component.php
@@ -188,6 +188,11 @@ class Component {
 			return;
 		}
 
+		/**
+		 * Whether to show component errors or not.
+		 *
+		 * @param bool $hide_notices Flag to hide/show notices.
+		 */
 		if ( apply_filters( 'wpcl_hide_component_errors_as_notices', false ) ) {
 			return;
 		}

--- a/inc/class-component.php
+++ b/inc/class-component.php
@@ -198,6 +198,7 @@ class Component {
 		}
 
 		foreach ( $this->error_reasons as $error ) {
+			// @todo Refactor this to use named hooks.
 			add_action(
 				'wpcl_admin_notices',
 				function() use ( $error ) {

--- a/inc/partials.php
+++ b/inc/partials.php
@@ -109,11 +109,11 @@ function wpcl_blocks( ?array $blocks = null ): void {
  */
 function wpcl_component( string $name, array $props = [], $return_output = false ): string {
 	ob_start();
-	$component                       = new Component( $name, $props );
-	$no_render_error_was_encountered = $component->render();
-	$output                          = ob_get_clean();
+	$component = new Component( $name, $props );
+	$success   = $component->render();
+	$output    = ob_get_clean();
 
-	if ( false === $no_render_error_was_encountered ) {
+	if ( false === $success ) {
 		return '';
 	}
 
@@ -122,8 +122,8 @@ function wpcl_component( string $name, array $props = [], $return_output = false
 		echo $output; // Already escaped in component template files.
 	}
 
-	// Default return can be treated as "truthy" to determine if the loading
-	// of the component was successful or not.
+	// Default return can be treated as "truthy" to determine if
+	// the rendering of the component was successful or not.
 	return $output;
 }
 

--- a/inc/partials.php
+++ b/inc/partials.php
@@ -104,11 +104,27 @@ function wpcl_blocks( ?array $blocks = null ): void {
  *
  * @param string $name  The name of the component to load.
  * @param array  $props Optional. An array of props for the component. Defaults to empty array.
- * @return bool If the component template file was found and rendered.
+ * @param bool   $return_output Optional. Whether to echo the output of the component or only return it.
+ * @return string Empty if the component template file was found and rendered. If the output was
  */
-function wpcl_component( string $name, array $props = [] ): bool {
-	$component = new Component( $name, $props );
-	return $component->render();
+function wpcl_component( string $name, array $props = [], $return_output = false ): string {
+	ob_start();
+	$component                       = new Component( $name, $props );
+	$no_render_error_was_encountered = $component->render();
+	$output                          = ob_get_clean();
+
+	if ( false === $no_render_error_was_encountered ) {
+		return '';
+	}
+
+	if ( false === $return_output ) {
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo $output; // Already escaped in component template files.
+	}
+
+	// Default return can be treated as "truthy" to determine if the loading
+	// of the component was successful or not.
+	return $output;
 }
 
 /**


### PR DESCRIPTION
## Summary

As titled.

## Notes for reviewers

None.

## Changelog entries

- **Added**:
- **Changed**:
- **Deprecated**:
- **Removed**:
- **Fixed**:
- **Security**:

## Issue(s)

None.
