### PR TITLE
Inline preview support

### DIFF
--- a/components/wpcl-admin-page/template.php
+++ b/components/wpcl-admin-page/template.php
@@ -16,9 +16,11 @@ $featured_component = ! empty( $args['component'] )
 // Print any admin notices from erroring components.
 do_action( 'wpcl_admin_notices' );
 
-if ( ! empty( $_GET['inline'] ) ) : ?>
+// phpcs:disable WordPressVIPMinimum.UserExperience.AdminBarRemoval.HidingDetected
+if ( ! empty( $_GET['inline'] ) ) : // phpcs:ignore WordPress.Security.NonceVerification.Recommended ?>
 	<style>
 		#wpadminbar, #adminmenumain, #wpfooter {
+			/* phpcs:ignore WordPressVIPMinimum.UserExperience.AdminBarRemoval.HidingDetected */
 			display: none !important;
 		}
 		html.wp-toolbar, #wpcontent {
@@ -35,6 +37,7 @@ if ( ! empty( $_GET['inline'] ) ) : ?>
 	</script>
 	<?php
 endif;
+// phpcs:enable WordPressVIPMinimum.UserExperience.AdminBarRemoval.HidingDetected
 
 // Get examples, if there are any.
 $examples       = $featured_component ? $featured_component->get_examples() : [];
@@ -57,7 +60,7 @@ if ( ! empty( $featured_component ) ) {
 		}
 	}
 	echo '<div style="margin-top: 1em">';
-	if ( empty( $_GET['inline'] ) ) {
+	if ( empty( $_GET['inline'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		wpcl_component(
 			'wpcl-button',
 			[
@@ -181,7 +184,7 @@ if ( ! empty( $featured_component ) ) {
 							return sprintf(
 								'<a href="%s" data-wpcl-preview="%s">%s</a>',
 								esc_url( wpcl_admin_url( $component->get_name(), $args['dogfooding'] ) ),
-								esc_url( wpcl_admin_url( $component->get_name(), $args['dogfooding'] ) . '&inline=true' ),
+								esc_url( add_query_arg( [ 'inline' => 'true' ], wpcl_admin_url( $component->get_name(), $args['dogfooding'] ) ) ),
 								$component->get_title()
 							);
 						},

--- a/components/wpcl-admin-page/template.php
+++ b/components/wpcl-admin-page/template.php
@@ -16,6 +16,26 @@ $featured_component = ! empty( $args['component'] )
 // Print any admin notices from erroring components.
 do_action( 'wpcl_admin_notices' );
 
+if ( ! empty( $_GET['inline'] ) ) : ?>
+	<style>
+		#wpadminbar, #adminmenumain, #wpfooter {
+			display: none !important;
+		}
+		html.wp-toolbar, #wpcontent {
+			padding: 0 !important;
+			margin: 0 !important;
+		}
+	</style>
+<?php else : ?>
+	<script type="text/javascript">
+		jQuery('body').on('click', 'a[data-wpcl-preview]', function(e){
+			e.preventDefault();
+			jQuery('#wpcl-component-preview-iframe').attr('src', e.target.dataset.wpclPreview);
+		});
+	</script>
+	<?php
+endif;
+
 // Get examples, if there are any.
 $examples       = $featured_component ? $featured_component->get_examples() : [];
 $total_examples = count( $examples );
@@ -37,16 +57,18 @@ if ( ! empty( $featured_component ) ) {
 		}
 	}
 	echo '<div style="margin-top: 1em">';
-	wpcl_component(
-		'wpcl-button',
-		[
-			'href' => wpcl_admin_url( '', $args['dogfooding'] ),
-			'text' => __(
-				'Back',
-				'wp-component-library'
-			),
-		]
-	);
+	if ( empty( $_GET['inline'] ) ) {
+		wpcl_component(
+			'wpcl-button',
+			[
+				'href' => wpcl_admin_url( '', $args['dogfooding'] ),
+				'text' => __(
+					'Back',
+					'wp-component-library'
+				),
+			]
+		);
+	}
 	echo '</div>';
 	wpcl_markdown( $featured_component->get_readme() );
 	wpcl_component(
@@ -149,18 +171,27 @@ if ( ! empty( $featured_component ) ) {
 		]
 	);
 	wpcl_component(
-		'wpcl-list',
+		'wpcl-layouts/sidebar-content',
 		[
-			'items' => array_map(
-				function ( Component $component ) use ( $args ) {
-					return sprintf(
-						'<a href="%s">%s</a>',
-						esc_url( wpcl_admin_url( $component->get_name(), $args['dogfooding'] ) ),
-						$component->get_title()
-					);
-				},
-				$args['components']
+			'sidebar' => wpcl_component(
+				'wpcl-list',
+				[
+					'items' => array_map(
+						function ( Component $component ) use ( $args ) {
+							return sprintf(
+								'<a href="%s" data-wpcl-preview="%s">%s</a>',
+								esc_url( wpcl_admin_url( $component->get_name(), $args['dogfooding'] ) ),
+								esc_url( wpcl_admin_url( $component->get_name(), $args['dogfooding'] ) . '&inline=true' ),
+								$component->get_title()
+							);
+						},
+						$args['components']
+					),
+				],
+				true
 			),
+			'content' => wpcl_component( 'wpcl-iframe-preview', [ 'id' => 'wpcl-component-preview-iframe' ], true ),
 		]
 	);
+
 }

--- a/components/wpcl-iframe-preview/README.md
+++ b/components/wpcl-iframe-preview/README.md
@@ -1,0 +1,3 @@
+# WPCL iFrame Preview
+
+A simple iFrame to be populated by JS (usually).

--- a/components/wpcl-iframe-preview/component.json
+++ b/components/wpcl-iframe-preview/component.json
@@ -1,0 +1,25 @@
+{
+  "examples": [
+    {
+      "props": {
+        "src": "https://alley.co",
+        "width": "800px",
+        "height": "500px"
+      }
+    }
+  ],
+  "title": "WPCL iFrame Preview",
+  "props": {
+    "src": {
+      "description": "The source of the iframe."
+    },
+    "width": {
+      "description": "The width of the iframe. Must be a valid CSS unit.",
+      "default": "100%"
+    },
+    "height": {
+      "description": "The height of the iframe. Must be a valid CSS unit.",
+      "default": "90vh"
+    }
+  }
+}

--- a/components/wpcl-iframe-preview/template.php
+++ b/components/wpcl-iframe-preview/template.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * WP Component Library Components: iFrame Preview
+ *
+ * @package WP_Component_Library
+ * @global array $args Arguments passed to this template part.
+ */
+
+?>
+<iframe
+	<?php wpcl_attributes( [ 'src' => $args['src'] ], $args ); ?>
+	style="
+		width: <?php echo esc_attr( $args['width'] ); ?>;
+		height: <?php echo esc_attr($args['height']); ?>;
+		background: rgba(0,0,0,0.25);
+	"
+></iframe>

--- a/components/wpcl-iframe-preview/template.php
+++ b/components/wpcl-iframe-preview/template.php
@@ -11,7 +11,7 @@
 	<?php wpcl_attributes( [ 'src' => $args['src'] ], $args ); ?>
 	style="
 		width: <?php echo esc_attr( $args['width'] ); ?>;
-		height: <?php echo esc_attr($args['height']); ?>;
+		height: <?php echo esc_attr( $args['height'] ); ?>;
 		background: rgba(0,0,0,0.25);
 	"
 ></iframe>

--- a/components/wpcl-layouts/sidebar-content/README.md
+++ b/components/wpcl-layouts/sidebar-content/README.md
@@ -1,0 +1,3 @@
+# WPCL Layout: Sidebar - Content
+
+A two column layout with a fixed sidebar and content.

--- a/components/wpcl-layouts/sidebar-content/component.json
+++ b/components/wpcl-layouts/sidebar-content/component.json
@@ -1,0 +1,19 @@
+{
+  "examples": [
+    {
+      "props": {
+        "sidebar": "<div style='background: red; min-height: 200px;'></div>",
+        "content": "<div style='background: rebeccapurple; min-height: 500px;'></div>"
+      }
+    }
+  ],
+  "props": {
+    "sidebar": {
+      "description": "HTML string of sidebar content."
+    },
+    "content": {
+      "description": "HTML string of main column content."
+    }
+  },
+  "title": "WPCL Layouts / Sidebar-Content"
+}

--- a/components/wpcl-layouts/sidebar-content/template.php
+++ b/components/wpcl-layouts/sidebar-content/template.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * WP Component Library Components: Layouts/Sidebar-Content
+ *
+ * @package WP_Component_Library
+ * @global array $args Arguments passed to this template part.
+ */
+
+?>
+<div style="display: grid; grid-gap: 1rem; grid-template-columns: minmax(min-content, 300px) 1fr;">
+	<div style="max-width: 300px;">
+		<?php echo $args['sidebar'] // phpcs:ignore ?>
+	</div>
+	<div>
+		<?php echo $args['content']; // phpcs:ignore ?>
+	</div>
+</div>

--- a/components/wpcl-layouts/sidebar-content/template.php
+++ b/components/wpcl-layouts/sidebar-content/template.php
@@ -9,9 +9,9 @@
 ?>
 <div style="display: grid; grid-gap: 1rem; grid-template-columns: minmax(min-content, 300px) 1fr;">
 	<div style="max-width: 300px;">
-		<?php echo $args['sidebar'] // phpcs:ignore ?>
+		<?php echo $args['sidebar']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 	</div>
 	<div>
-		<?php echo $args['content']; // phpcs:ignore ?>
+		<?php echo $args['content']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 	</div>
 </div>


### PR DESCRIPTION
## Summary

See attached video for example

https://user-images.githubusercontent.com/4062087/141505562-f78106f2-4ff2-4ac5-914a-71cf77d2fd36.mp4

## Notes for reviewers

Inline CSS was used for styling since the plugin currently doesn't have any sort of asset build pipeline directly.

## Changelog entries

- **Added**:
- **Changed**:
- **Deprecated**:
- **Removed



**:
- **Fixed**:
- **Security**:

## Issue(s)

None.
