### PR TITLE
adding filter to wpcl_blocks

### DIFF
--- a/inc/partials.php
+++ b/inc/partials.php
@@ -92,7 +92,12 @@ function wpcl_attributes( array $attributes, ?array $args = null ): void {
 function wpcl_blocks( ?array $blocks = null ): void {
 	global $post;
 
-	$blocks ??= parse_blocks( $post->post_content );
+	/**
+	 * Allows for modification of the Gutenberg blocks that will be rendered.
+	 *
+	 * @param array $blocks The parsed Gutenberg Blocks.
+	 */
+	$blocks ??= apply_filters( 'wpcl_blocks', parse_blocks( $post->post_content ) );
 
 	foreach ( $blocks as $block ) {
 		Block_Parser::factory( $block )->render();


### PR DESCRIPTION
## Summary

Allows for modifying the blocks before render for purposes such as inserting ads.
Example usage:
```
/**
 * A function to test inserting ads.
 *
 * @param [array] $blocks The existing blocks.
 * @return array
 */
function test_insert_ads( $blocks ) {
	$blocks = Bass_Ads::instance()->insert_ads_into_blocks( $blocks, 'dfp-ad-banner_top', 2, 5 );
	return $blocks;
}
add_filter( 'wpcl_blocks', __NAMESPACE__ . '\test_insert_ads' );

```

## Notes for reviewers

None.

## Changelog entries

- **Added**:
- **Changed**:
- **Deprecated**:
- **Removed**:
- **Fixed**:
- **Security**:

## Issue(s)

None.
