### PR TITLE
Set correct package type in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "phpcs": "phpcs . --runtime-set text_domain wp-component-library",
     "phpunit": "phpunit"
   },
-  "type": "project",
+  "type": "wordpress-plugin",
   "config": {
     "allow-plugins": {
       "dealerdirect/phpcodesniffer-composer-installer": true


### PR DESCRIPTION
## Summary

This change makes it possible to load this plugin using composer.json.

## Changelog entries

- **Changed**:

Changed package type from `project` to `wordpress-plugin`.