### PR TITLE
Moving to shared workflow, updating set-output

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/dependabot-auto-approve.yml
+++ b/.github/workflows/dependabot-auto-approve.yml
@@ -1,0 +1,11 @@
+name: dependabot-auto-approve
+on:
+  pull_request:
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  dependabot:
+    uses: alleyinteractive/.github/.github/workflows/dependabot-auto-approve.yml@main

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,10 @@
+name: dependabot-auto-merge
+on: pull_request_target
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  dependabot:
+    uses: alleyinteractive/.github/.github/workflows/dependabot-auto-merge.yml@main

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,53 +1,14 @@
-name: Linting
+name: Coding Standards
 
 on:
+  push:
+    branches:
+      - develop
+      - main
   pull_request:
+  schedule:
+    - cron: '0 0 * * *'
 
 jobs:
   coding-standards:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-
-    name: Coding Standards
-    steps:
-      - name: Cancel previous runs of this workflow (pull requests only)
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: styfle/cancel-workflow-action@0.5.0
-        with:
-          access_token: ${{ github.token }}
-
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Get Composer cache directory
-        id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-      - name: Set up Composer caching
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-composer-dependencies
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-composer-
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.0'
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, gd
-          tools: composer:v2
-          coverage: none
-
-      - name: Install composer dependencies
-        uses: nick-invision/retry@v1
-        with:
-          timeout_minutes: 5
-          max_attempts: 5
-          command: composer install
-
-      - name: Coding standards
-        run: composer phpcs
+    uses: alleyinteractive/.github/.github/workflows/php-coding-standards.yml@main

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Get Composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Set up Composer caching
         uses: actions/cache@v2
@@ -73,7 +73,7 @@ jobs:
       - name: Install WordPress and Copy Project
         shell: bash
         run: |
-          bash <(curl -s "https://raw.githubusercontent.com/wp-cli/sample-plugin/master/bin/install-wp-tests.sh") wordpress_test root '' 127.0.0.1 latest
+          bash <(curl -s "https://raw.githubusercontent.com/wp-cli/sample-plugin/HEAD/bin/install-wp-tests.sh") wordpress_test root '' 127.0.0.1 latest
           rm -rf "${WP_CORE_DIR}wp-content/plugins"
           mkdir -p "${WP_CORE_DIR}wp-content/plugins/wp-component-library"
           rsync -a --exclude=.git . "${WP_CORE_DIR}wp-content/plugins/wp-component-library"

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -23,7 +23,7 @@ jobs:
         can_fail: [false]
         multisite: [0,1]
 
-    name: phpunit '8.0' @ WP ${{ matrix.wp_version }} WP_MULTISITE=${{ matrix.multisite }}
+    name: phpunit 8.0 @ WP ${{ matrix.wp_version }} WP_MULTISITE=${{ matrix.multisite }}
     env:
       CACHEDIR: /tmp/test-cache
       WP_CORE_DIR: /tmp/wordpress/

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "authors": [
     {
       "name": "Alley Interactive",
-      "email": "noreply@alleyinteractive.com"
+      "email": "info@alley.com"
     }
   ],
   "autoload": {


### PR DESCRIPTION
- Moving one workflow to a shared workflow from `alleyinteractive/.github`.
- Updating another to not use `set-output` since it is deprecated.